### PR TITLE
Move New Relic to the end of the role

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,10 @@ jobs:
             - .venv
       - run:
           name: test
-          command: pipenv run molecule test --all
+          command: pipenv run molecule test --all 2>&1 | tee /tmp/molecule.log
+      - store_artifacts:
+          path: /tmp/molecule.log
+          destination: molecule.log
 
 
 workflows:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,14 +74,6 @@
   tags:
     - postfix
 
-- name: Install newrelic infrastructure agent
-  include_role:
-    name: newrelic.newrelic-infra
-  when: common_newrelic_enabled
-  tags:
-    - newrelic
-    - molecule-notest      # to fix
-
 - name: Install secops filebeat agent
   include_role:
     name: gsa.ansible-role-beats
@@ -124,4 +116,16 @@
   when: trendmicro_enabled
   tags:
     - trendmicro
+    - molecule-notest      # to fix
+
+# Any service monitored by New Relic should've been started by now. We put this
+# at the end to avoid getting alerts when first provisioning a machine.
+# Otherwise, we'll start monitoring and alerting on things that might not have
+# been provisioned yet.
+- name: Install newrelic infrastructure agent
+  include_role:
+    name: newrelic.newrelic-infra
+  when: common_newrelic_enabled
+  tags:
+    - newrelic
     - molecule-notest      # to fix


### PR DESCRIPTION
This prevents us from alerting on services that haven't been provisioned yet.