### PR TITLE
Add missing python build dependencies

### DIFF
--- a/vars/bionic.yml
+++ b/vars/bionic.yml
@@ -16,3 +16,23 @@ common_os_packages:
   - python-setuptools
   - python-virtualenv
   - ruby-dev
+
+  # python dependencies
+  - build-essential
+  - curl
+  - git
+  - libbz2-dev
+  - libffi-dev
+  - liblzma-dev
+  - libncurses5-dev
+  - libncursesw5-dev
+  - libreadline-dev
+  - libsqlite3-dev
+  - libssl-dev
+  - llvm
+  - make
+  - python-openssl
+  - tk-dev
+  - wget
+  - xz-utils
+  - zlib1g-dev

--- a/vars/xenial.yml
+++ b/vars/xenial.yml
@@ -16,3 +16,23 @@ common_os_packages:
   - python-setuptools
   - python-virtualenv
   - ruby-dev
+
+  # python dependencies
+  - build-essential
+  - curl
+  - git
+  - libbz2-dev
+  - libffi-dev
+  - liblzma-dev
+  - libncurses5-dev
+  - libncursesw5-dev
+  - libreadline-dev
+  - libsqlite3-dev
+  - libssl-dev
+  - llvm
+  - make
+  - python-openssl
+  - tk-dev
+  - wget
+  - xz-utils
+  - zlib1g-dev


### PR DESCRIPTION
This allows python to build optional modules like openssl, zlib, bzip, etc, which are required for ckan deps.