### PR TITLE
Use import_* instead of include_*

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
-- include_tasks: hostname.yml
+- import_tasks: hostname.yml
   tags:
     - hostname
 
 - name: Hardening for Ubuntu Trusty
-  include_role:
+  import_role:
     name: gsa.ansible-os-ubuntu-14
   when: ansible_distribution_release == "trusty"
   tags:
@@ -12,7 +12,7 @@
     - molecule-notest
 
 - name: Hardening for Ubuntu Xenial or Bionic
-  include_role:
+  import_role:
     name: gsa.ansible-os-ubuntu-16
   when: ansible_distribution_release == "bionic" or ansible_distribution_release == "xenial"
   tags:
@@ -20,77 +20,77 @@
     - molecule-notest
 
 - name: Install upstart for Ubuntu Trusty
-  include_role:
+  import_role:
     name: dwcramer.upstart
   when: ansible_distribution_release == "trusty"
 
 - name: Install build-essential
-  include_role:
+  import_role:
     name: ANXS.build-essential
 
 - name: Install apt-utils
-  include_role:
+  import_role:
     name: ANXS.apt
 
-- include_tasks: system-packages.yml
+- import_tasks: system-packages.yml
   tags:
     - system-packages
 
-- include_tasks: tls.yml
+- import_tasks: tls.yml
   tags:
     - tls
 
 - name: Install unattended-upgrades
-  include_role:
+  import_role:
     name: jnv.unattended-upgrades
   tags:
     - unattended-upgrades
 
 - name: Install postfix mail server
-  include_role:
+  import_role:
     name: oefenweb.postfix
   tags:
     - postfix
 
 - name: Install secops filebeat agent
-  include_role:
+  import_role:
     name: gsa.ansible-role-beats
   when: filebeat_enabled
   tags:
     - filebeat
 
 - name: Install logrotate
-  include_role:
+  import_role:
     name: nickhammond.logrotate
   tags:
     - logrotate
 
-- include_tasks: ca-certficates.yml
+- import_tasks: ca-certficates.yml
   tags:
     - ca-certificates
 
-- include_tasks: grub.yml
+- import_tasks: grub.yml
   tags:
     - grub
 
-- include_tasks: nessus.yml
+- import_tasks: nessus.yml
   when: nessus_agent_enabled
   tags:
     - nessus
 
-- include_tasks: ntp.yml
+- import_tasks: ntp.yml
   tags:
     - ntp
 
-- include_tasks: python-upgrade.yml
+- import_tasks: python-upgrade.yml
   tags:
     - python-upgrade
 
-- include_tasks: reboot-notify.yml
+- import_tasks: reboot-notify.yml
   tags:
     - reboot-notify
 
-- include_tasks: trendmicro.yml
+- import_tasks: trendmicro.yml
   when: trendmicro_enabled
   tags:
     - trendmicro
@@ -101,7 +101,7 @@
 # Otherwise, we'll start monitoring and alerting on things that might not have
 # been provisioned yet.
 - name: Install newrelic infrastructure agent
-  include_role:
+  import_role:
     name: newrelic.newrelic-infra
   when: common_newrelic_enabled
   tags:


### PR DESCRIPTION
Fixes https://github.com/GSA/datagov-deploy-common/issues/17

include* is used for dynamic operation and import* is
used for static operation. Based on the behavior described[1], we want the
static operation so that tags and when statements are "copied" to all imported
tasks/roles. We're not using any dynamic functionality here.

[1]: https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse.html#differences-between-static-and-dynamic