### PR TITLE
Add supervisor to systemd hosts

### DIFF
--- a/vars/bionic.yml
+++ b/vars/bionic.yml
@@ -9,6 +9,7 @@ common_os_packages:
   - ntp
   - reboot-notifier
   - ruby
+  - supervisor
   - systemd
   - software-properties-common
   - python-dev

--- a/vars/bionic.yml
+++ b/vars/bionic.yml
@@ -4,19 +4,19 @@ common_os_packages:
   - atool
   - cron
   - git
-  - nano
   - htop
+  - nano
   - ntp
-  - reboot-notifier
-  - ruby
-  - supervisor
-  - systemd
-  - software-properties-common
   - python-dev
   - python-pip
   - python-setuptools
   - python-virtualenv
+  - reboot-notifier
+  - ruby
   - ruby-dev
+  - software-properties-common
+  - supervisor
+  - systemd
 
   # python dependencies
   - build-essential

--- a/vars/trusty.yml
+++ b/vars/trusty.yml
@@ -5,7 +5,6 @@ common_os_packages:
   - bison
   - cron
   - git
-  - nano
   - htop
   - lib32z1-dev
   - libbz2-dev
@@ -15,7 +14,7 @@ common_os_packages:
   - libssl-dev
   - libxml2-dev
   - libxslt1-dev
-  - software-properties-common
+  - nano
   - postgresql-client
   - python-dev
   - python-pip
@@ -23,4 +22,5 @@ common_os_packages:
   - python-virtualenv
   - ruby
   - ruby-dev
+  - software-properties-common
   - supervisor

--- a/vars/xenial.yml
+++ b/vars/xenial.yml
@@ -9,6 +9,7 @@ common_os_packages:
   - ntp
   - reboot-notifier
   - ruby
+  - supervisor
   - systemd
   - software-properties-common
   - python-dev

--- a/vars/xenial.yml
+++ b/vars/xenial.yml
@@ -4,19 +4,19 @@ common_os_packages:
   - atool
   - cron
   - git
-  - nano
   - htop
+  - nano
   - ntp
-  - reboot-notifier
-  - ruby
-  - supervisor
-  - systemd
-  - software-properties-common
   - python-dev
   - python-pip
   - python-setuptools
   - python-virtualenv
+  - reboot-notifier
+  - ruby
   - ruby-dev
+  - software-properties-common
+  - supervisor
+  - systemd
 
   # python dependencies
   - build-essential


### PR DESCRIPTION
Originally the plan was to replace supervisor with systemd service files for any
platform services. We haven't done that work yet, so keep supervisor installed
on these hosts for now.