### PR TITLE
[upstart] fix broken logrotate

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,14 @@
   import_role:
     name: dwcramer.upstart
   when: ansible_distribution_release == "trusty"
+  tags:
+    - upstart
+
+- name: Remove broken upstart log rotation
+  file: path=/etc/logrotate.d/upstart state=absent
+  when: ansible_distribution_release == "trusty"
+  tags:
+    - upstart
 
 - name: Install build-essential
   import_role:


### PR DESCRIPTION
Fixes error:

```
/etc/cron.daily/logrotate:
error: upstart:7 unknown user 'upstart'
error: found error in /var/log/upstart/*.log , skipping
```