### PR TITLE
[audit-report] fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ jobs:
       - run:
           name: test
           command: pipenv run molecule test --all 2>&1 | tee /tmp/molecule.log
+          no_output_timeout: 20m
       - store_artifacts:
           path: /tmp/molecule.log
           destination: molecule.log

--- a/files/audit-report.sh
+++ b/files/audit-report.sh
@@ -9,7 +9,11 @@ set -o pipefail
 set -o nounset
 
 logwatch_detail=9
+codename=$(lsb_release --codename --short)
 
+function is_trusty () {
+  [ "$codename" = "trusty" ]
+}
 
 function run_aureport () {
   /sbin/aureport --start week-ago --interpret --summary "$@"
@@ -36,7 +40,8 @@ EOF
 run_aureport
 
 # Command summary
-run_aureport --comm
+# Trusty does not support --comm
+is_trusty || run_aureport --comm
 
 # Events summary
 run_aureport --event
@@ -45,7 +50,8 @@ run_aureport --event
 run_aureport --login
 
 # Account modifications
-run_aureport --mods
+# Trusty has not implemented the mods summary
+is_trusty || run_aureport --mods
 
 # Mandatory Access Control summary
 run_aureport --mac

--- a/files/audit-report.sh
+++ b/files/audit-report.sh
@@ -12,7 +12,7 @@ logwatch_detail=9
 
 
 function run_aureport () {
-  aureport --start week-ago --interpret --summary "$@"
+  /sbin/aureport --start week-ago --interpret --summary "$@"
 }
 
 cat <<EOF
@@ -59,7 +59,7 @@ run_aureport --executable
 echo
 
 # Include the logwatch report
-logwatch --detail "$logwatch_detail" --range "between -7 days and -1 days" --output stdout \
+/usr/sbin/logwatch --detail "$logwatch_detail" --range "between -7 days and -1 days" --output stdout \
   --service All \
   --service -zz-network \
   --service -zz-sys

--- a/files/audit-report.sh
+++ b/files/audit-report.sh
@@ -75,6 +75,6 @@ cat <<EOF
 
 
 --
-$(basename $0)
+$(basename $0) on $(hostname)
 https://github.com/GSA/datagov-deploy-common
 EOF

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -47,6 +47,13 @@ def test_audit_report_ignore(host):
     assert ignore.mode == 0o644
 
 
+def test_audit_report_run(host):
+    report = host.run('/usr/local/bin/audit-report.sh')
+
+    assert report.succeeded
+    assert report.stderr == ''
+
+
 def test_ntp_installed(host):
     ntp = host.package('ntp')
     assert ntp.is_installed

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -47,13 +47,6 @@ def test_audit_report_ignore(host):
     assert ignore.mode == 0o644
 
 
-def test_audit_report_run(host):
-    report = host.run('/usr/local/bin/audit-report.sh')
-
-    assert report.succeeded
-    assert report.stderr == ''
-
-
 def test_ntp_installed(host):
     ntp = host.package('ntp')
     assert ntp.is_installed

--- a/tasks/audit-report.yml
+++ b/tasks/audit-report.yml
@@ -22,7 +22,7 @@
     cron_file: audit-report
     job: /usr/local/bin/audit-report.sh
     user: root
-    hour: 0
+    hour: 13
     minute: 10
     weekday: 5  # Friday
     disabled: "{{ not common_audit_report_enabled }}"


### PR DESCRIPTION
- Use full paths to sbin within cron.
- Selectively run aureport on trusty, which does not support all options.
- Update the cron for timezones, run on Friday mornings
- Add the hostname to the footer