### PR TITLE
[audit-report] fix data appearing from aureport

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ jobs:
       - run:
           name: test
           command: pipenv run molecule test --all 2>&1 | tee /tmp/molecule.log
-          no_output_timeout: 20m
       - store_artifacts:
           path: /tmp/molecule.log
           destination: molecule.log

--- a/files/audit-report.sh
+++ b/files/audit-report.sh
@@ -16,7 +16,7 @@ function is_trusty () {
 }
 
 function run_aureport () {
-  /sbin/aureport --start week-ago --interpret --summary "$@"
+  /sbin/aureport --input-logs --start week-ago --interpret --summary "$@"
 }
 
 cat <<EOF

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -47,6 +47,13 @@ def test_audit_report_ignore(host):
     assert ignore.mode == 0o644
 
 
+def test_audit_report_run(host):
+    report = host.run('/usr/local/bin/audit-report.sh')
+
+    assert report.succeeded
+    assert report.stderr == ''
+
+
 def test_ntp_installed(host):
     ntp = host.package('ntp')
     assert ntp.is_installed


### PR DESCRIPTION
The test hanging was the same reason why we're not seeing any data in the report. aureport is reading from stdin when used non-interactively. Specify the input logs from configuration and restore the test.