### PR TITLE
[trendmicro] remove inventory groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,16 @@ Install the host certificate and key.
 
 On-host SecOps managed firewall.
 
+**`trendmicro_enabled`** boolean (default: false)
+
+Enable or disable trendmicro install. Setting this to false does not remove
+trendmicro.
+
+**`trendmicro_policy_id`** boolean **required**
+
+This is required when trendmicro_enabled is set. This is the numeric policy id
+that should be applied to this host and is assigned by SecOps.
+
 
 #### unattended-upgrades
 

--- a/tasks/trendmicro.yml
+++ b/tasks/trendmicro.yml
@@ -20,7 +20,7 @@
   tags:
     - skip_ansible_lint
 
-- name: register trenmicro agent
+- name: register trendmicro agent
   command: /opt/ds_agent/dsa_control -a dsm://dsm.sec.helix.gsa.gov:4120/ "policyid:{{ trendmicro_policy_id }}"
   # TODO clarify if jumpbox should have a policy id
   # In general, when trendmicro_enabled is true, a policy id should be set for

--- a/tasks/trendmicro.yml
+++ b/tasks/trendmicro.yml
@@ -7,42 +7,24 @@
   register: result
   retries: 3
   delay: 30
-  until: result | success
+  until: result is success
 
 - name: Install trendmicro
   apt:
     deb: "/tmp/trendmicro.deb"
+  register: trendmicro_installed
 
 - name: sleep 10 seconds
   command: sleep 10
+  when: trendmicro_installed is changed
   tags:
     - skip_ansible_lint
 
-# TODO make trendmicro_policy_id an explicit variable
-# Hard-coding inventory groups doesn't work well. If the group doesn't exist,
-# you'll get errors trying to iterate over an undefined group.  The policy Id
-# should be defined explicitly as part of the group inventory variables.
-- name: start trendmicro agent @ web tier
-  command: /opt/ds_agent/dsa_control -a dsm://dsm.sec.helix.gsa.gov:4120/ "policyid:{{ trendmicro_policy_id_web }}"
-  when: |
-        (inventory_hostname in groups["catalog-web"]) or
-        (inventory_hostname in groups["inventory-web"]) or
-        (inventory_hostname in groups["crm-web"]) or
-        (inventory_hostname in groups["dashboard-web"]) or
-        (inventory_hostname in groups["wordpress-web"])
-
-- name: start trendmicro agent @ app tier
-  command: /opt/ds_agent/dsa_control -a dsm://dsm.sec.helix.gsa.gov:4120/ "policyid:{{ trendmicro_policy_id_app }}"
-  when: |
-    (inventory_hostname in groups["solr"]) or
-    (inventory_hostname in groups["catalog-harvester"])
-
-- name: start trendmicro agent @ mgmt web tier
-  command: /opt/ds_agent/dsa_control -a dsm://dsm.sec.helix.gsa.gov:4120/ "policyid:{{ trendmicro_policy_id_mgmt_web }}"
-  when: ("efk_nginx" in groups) and (inventory_hostname in groups["efk_nginx"])
-
-- name: start trendmicro agent @ mgmt app tier
-  command: /opt/ds_agent/dsa_control -a dsm://dsm.sec.helix.gsa.gov:4120/ "policyid:{{ trendmicro_policy_id_mgmt_app }}"
-  when: |
-    (("kibana" in groups) and (inventory_hostname in groups["kibana"])) or
-    (("elasticsearch" in groups) and (inventory_hostname in groups["elasticsearch"]))
+- name: register trenmicro agent
+  command: /opt/ds_agent/dsa_control -a dsm://dsm.sec.helix.gsa.gov:4120/ "policyid:{{ trendmicro_policy_id }}"
+  # TODO clarify if jumpbox should have a policy id
+  # In general, when trendmicro_enabled is true, a policy id should be set for
+  # each host in the environment. Currently, jumpboxes do not have a
+  # trendmicro policy. If we find that jumpboxes _should_ have a policy id,
+  # then we should make an assertion.
+  when: trendmicro_policy_id is defined


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/1389

As the comment mentioned, this creates removes the hard dependency of having
these inventory groups. We ran into this again when removing crm-web. This makes
it explicit that trendmicro_policy_id should be set.