### PR TITLE
[filebeat] don't pin version in apt

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ common_python_version_name: Python-{{ common_python_version_number }}
 
 # filebeat
 filebeat_enabled: false
+beats_hold_products: false  # Don't pin versions in apt.
 
 
 # postfix


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy-common/issues/24
Always pull in the latest version with the latest fixes and security updates.