### PR TITLE
[filebeat] version specifier for filebeat

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,7 +14,6 @@ common_python_version_name: Python-{{ common_python_version_number }}
 
 # filebeat
 filebeat_enabled: false
-beats_hold_products: false  # Don't pin versions in apt.
 
 
 # postfix

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,6 +71,7 @@
     # Don't pin the version, allow filebeat to be updated
     # from apt
     beats_hold_products: false
+    beats_ver: "6.*"  # apt-get version specifier. We want the latest 6.x
     beats_products:
       - filebeat
   when: filebeat_enabled


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy-common/issues/24

Right, default variables only apply to the role, so they won't be applied to the third-party jobscore.beats role. Apply the version specifier at the import task.