### PR TITLE
Fix path for ua subscription

### DIFF
--- a/tasks/ua.yml
+++ b/tasks/ua.yml
@@ -8,6 +8,6 @@
 - name: attach ubuntu advantage client
   command:
     cmd: ua attach {{ common_ubuntu_advantage_token }}
-    creates: /etc/ubuntu-advantage/uaclient.conf
+    creates: /var/lib/ubuntu-advantage/status.json
   tags:
     - molecule-notest


### PR DESCRIPTION
/etc/ubuntu-advantage exists once ua is installed, but the data directory,
/var/lib/ubuntu-advantage is only populated after subscription.