### PR TITLE
[trendmicro] "fix" hang during registration

### DIFF
--- a/tasks/trendmicro.yml
+++ b/tasks/trendmicro.yml
@@ -23,12 +23,21 @@
     deb: "/tmp/trendmicro.deb"
   register: trendmicro_installed
 
-- name: sleep 10 seconds
-  command: sleep 10
-  when: trendmicro_installed is changed
-  tags:
-    - skip_ansible_lint
-
 - name: register trendmicro agent
   command: /opt/ds_agent/dsa_control -a dsm://dsm.sec.helix.gsa.gov:4120/ "policyid:{{ trendmicro_policy_id }}"
   when: trendmicro_policy_id is defined
+  register: trendmicro_register
+  ignore_errors: true
+  async: 120
+  poll: 10
+  retries: 1
+  delay: 10
+  until: trendmicro_register is success
+
+- name: manually register trendmicro agent
+  when: trendmicro_register is failed
+  fail:
+    msg: >-
+      Occasionally trendmicro registration will timeout. Re-run the playbook
+      with `--skip-tags trendmicro` and contact the firewall team for them to
+      manually register the failed instance or provide debugging support.


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/1825

Seeing a hang on the registration task after installing trend on a new instance.
Registration output shows 30 retries at 30 seconds each, which is too long to
wait. The GSA Firewall team says partial registration can happen on occasion and
may require a manual fix on their end. Add a timeout and actionable debug
message when this happens.

Presumably the 10 second sleep was added due to some kind of hang or hiccup
while trendmicro is starting up immediately after install. Use `retries` and
`delay` instead to achieve better robustness without an unnecessary sleep.