### PR TITLE
add symlink of host certificate

### DIFF
--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -102,6 +102,14 @@ def test_certificate(host):
     assert f.group == 'root'
 
 
+def test_certificate_symlink(host):
+    f = host.file('/usr/local/share/ca-certificates/datagov_host.crt')
+
+    assert f.is_symlink
+    assert f.linked_to == '/etc/ssl/certs/datagov_host.crt'
+    assert f.user == 'root'
+
+
 def test_key(host):
     f = host.file('/etc/ssl/private/datagov_host.key')
 

--- a/tasks/tls.yml
+++ b/tasks/tls.yml
@@ -22,6 +22,13 @@
     owner: root
     group: root
 
+- name: create a symlink of host certificate
+  file:
+    src: /etc/ssl/certs/datagov_host.crt
+    dest: /usr/local/share/ca-certificates/datagov_host.crt
+    owner: root
+    state: link
+
 - name: copy host key
   copy:
     dest: /etc/ssl/private/datagov_host.key


### PR DESCRIPTION
part of https://github.com/GSA/datagov-deploy/issues/1855

Command `update-ca-certificates` is not updating `/etc/ssl/certs/ca-certificates.crt` after change https://github.com/GSA/datagov-deploy/pull/1856. It turns out `/etc/ssl/certs/` only works for new cert file. To let existing cert get picked up by `update-ca-certificates`, it needs be put in directory `/usr/local/share/ca-certificates/`.