### PR TITLE
Initial common operators removal fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ common_operators:
   - username: userone
     email: userone@example.com
     public_key: ssh-rsa aabbccddeeff1234567890 comment
-    active: true
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ Tasks for OS hardening.
 
 Includes the hostname tasks to update /etc/hosts and hostname.
 
+#### jumpbox_ips
+
+The IP of the jumpbox to limit SSH access from jumpbox only. Defaults to `*` to allow access from anywhere.
 
 #### logrotate
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,9 @@ common_python_version_name: Python-{{ common_python_version_number }}
 # filebeat
 filebeat_enabled: false
 
+# By default allow SSH access from anywhere, can specify jumpbox ip to limit
+jumpbox_ip: "*"
+
 
 # postfix
 postfix_debconf_selections:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ common_python_version_name: Python-{{ common_python_version_number }}
 filebeat_enabled: false
 
 # By default allow SSH access from anywhere, can specify jumpbox ip to limit
-jumpbox_ip: "*"
+jumpbox_ips: ['*']
 
 
 # postfix

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -9,10 +9,6 @@
           - username: operator1
             email: operator1@example.com
             public_key: ssh-rsa key operator1@example.com
-            active: true
-          - username: operator_inactive
-            email: operator_inactive@example.com
-            public_key: "{{ inactive_operator_key }}"
         filebeat_enabled: true
         filebeat_config:
           filebeat.config.modules:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -15,6 +15,7 @@
         group: ubuntu
         mode: "0640"
         content: |
+          ssh-rsa root_key root@example.com
           # BEGIN ANSIBLE MANAGED LIST OF USERS
           {{ inactive_operator_key }}
           # END ANSIBLE MANAGED LIST OF USERS

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -15,4 +15,6 @@
         group: ubuntu
         mode: "0640"
         content: |
+          # BEGIN ANSIBLE MANAGED LIST OF USERS
           {{ inactive_operator_key }}
+          # END ANSIBLE MANAGED LIST OF USERS

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -6,6 +6,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 operator_key = 'ssh-rsa key operator1@example.com'
+root_key = 'ssh-rsa root_key root@example.com'
 inactive_operator_key = 'ssh-rsa key operator_inactive@example.com'
 
 
@@ -123,4 +124,5 @@ def test_operator_keys(host):
     authorized_keys = host.file('/home/ubuntu/.ssh/authorized_keys')
 
     assert authorized_keys.contains(operator_key)
+    assert authorized_keys.contains(root_key)
     assert not authorized_keys.contains(inactive_operator_key)

--- a/molecule/ua/tests/test_default.py
+++ b/molecule/ua/tests/test_default.py
@@ -5,9 +5,6 @@ import testinfra.utils.ansible_runner
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
-operator_key = 'ssh-rsa key operator1@example.com'
-inactive_operator_key = 'ssh-rsa key operator_inactive@example.com'
-
 
 def test_ua_package(host):
     package = host.package("ubuntu-advantage-tools")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,7 +40,7 @@
 
 - name: Create block of current user keys
   set_fact:
-    common_operator_key_block: "from=\"{{ jumpbox_ip }}\" {{ common_operators | join('\n from=\"{{ jumpbox_ip }}\"', attribute='public_key') }}"
+    common_operator_key_block: "from=\"{{ jumpbox_ip }}\" {{ common_operators | join('\n from=\"{{ jumpbox_ip }}\" ', attribute='public_key') }}"
 
 - name: Remove all current user keys
   blockinfile:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,9 +38,21 @@
   tags:
     - upstart
 
-- name: Install operator SSH keys
-  lineinfile: path=/home/ubuntu/.ssh/authorized_keys line={{ item.public_key }} state={{ item.active | default(false) | ternary('present', 'absent') }}
-  loop: "{{ common_operators }}"
+- name: Create block of current user keys
+  set_fact:
+    common_operator_key_block: "from=\"{{ jumpbox_ip }}\" {{ common_operators | join('\n from=\"{{ jumpbox_ip }}\"', attribute='public_key') }}"
+
+- name: Remove all current user keys
+  blockinfile:
+    path: /home/ubuntu/.ssh/authorized_keys
+    state: absent
+    marker: "# {mark} ANSIBLE MANAGED LIST OF USERS"
+
+- name: blockinfile insert
+  blockinfile:
+    path: /home/ubuntu/.ssh/authorized_keys
+    block: "{{ common_operator_key_block }}"
+    marker: "# {mark} ANSIBLE MANAGED LIST OF USERS"
 
 - name: Install build-essential
   import_role:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,20 +38,13 @@
   tags:
     - upstart
 
-- name: Create block of current user keys
-  set_fact:
-    common_operator_key_block: "from=\"{{ jumpbox_ip }}\" {{ common_operators | join('\n from=\"{{ jumpbox_ip }}\" ', attribute='public_key') }}"
-
-- name: Remove all current user keys
+- name: Install operator keys to ubuntu user, restricted to jumpbox
   blockinfile:
     path: /home/ubuntu/.ssh/authorized_keys
-    state: absent
-    marker: "# {mark} ANSIBLE MANAGED LIST OF USERS"
-
-- name: blockinfile insert
-  blockinfile:
-    path: /home/ubuntu/.ssh/authorized_keys
-    block: "{{ common_operator_key_block }}"
+    block: |
+      {% for operator in common_operators %}
+      from="{{ jumpbox_ips | join(',') }}" {{ operator.public_key }}
+      {% endfor %}
     marker: "# {mark} ANSIBLE MANAGED LIST OF USERS"
 
 - name: Install build-essential


### PR DESCRIPTION
- Remove `active` functionality for common_operators list, and manage ssh key creation as a block per [this change](https://github.com/GSA/datagov-deploy/issues/1837)
- Add `from` clause for authorized_keys file so [access can be limited](https://github.com/GSA/datagov-deploy/issues/1203)

**Note: Will require cleanup once run on all systems.**