### PR TITLE
Rebuild python with gdbm support for pysaml2 in CKAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ URL to download python from.
 Python filename.
 
 
+**`force_rebuild_python`** boolean (default: false)
+
+Force a rebuild of our custom python. In case you want to rebuild python with
+additional features, use this flag to force the rebuild.
+
+
+
 ### Tags
 
 You can run the playbook with these tags for quicker or targeted plays.

--- a/tasks/python-upgrade.yml
+++ b/tasks/python-upgrade.yml
@@ -25,7 +25,11 @@
 
 - name: shall we rebuild python?
   set_fact:
-    rebuild_python: "{{ (force_rebuild_python | default(False)) or not python_dir.stat.exists or python_version_check is failed or not python_shared_lib.stat.exists }}"
+    rebuild_python: >-
+      {{ (force_rebuild_python | default(False))
+      or not python_dir.stat.exists
+      or python_version_check is failed
+      or not python_shared_lib.stat.exists }}
 
 - name: Display
   debug:

--- a/tasks/python-upgrade.yml
+++ b/tasks/python-upgrade.yml
@@ -25,7 +25,7 @@
 
 - name: shall we rebuild python?
   set_fact:
-    rebuild_python: "{{ (force_python_rebuild | default(False)) or not python_dir.stat.exists or python_version_check is failed or not python_shared_lib.stat.exists }}"
+    rebuild_python: "{{ (force_rebuild_python | default(False)) or not python_dir.stat.exists or python_version_check is failed or not python_shared_lib.stat.exists }}"
 
 - name: Display
   debug:

--- a/tasks/python-upgrade.yml
+++ b/tasks/python-upgrade.yml
@@ -23,12 +23,20 @@
   when: python_dir.stat.exists
   tags: skip_ansible_lint
 
+- name: shall we rebuild python?
+  set_fact:
+    rebuild_python: "{{ (force_python_rebuild | default(False)) or not python_dir.stat.exists or python_version_check is failed or not python_shared_lib.stat.exists }}"
+
+- name: Display
+  debug:
+    msg: "{{ rebuild_python }}"
+
 - name: unpack new python
   unarchive:
     src: "{{ common_python_version_url }}"
     dest: /var/tmp/
     remote_src: yes
-  when: not python_dir.stat.exists or python_version_check is failed or not python_shared_lib.stat.exists
+  when: rebuild_python
   register: result
   until: not result.failed
   retries: 3
@@ -38,13 +46,13 @@
   command: "./configure --prefix {{ common_python_version_directory }} --enable-ipv6 --enable-unicode=ucs4 --enable-shared"
   args:
     chdir: "/var/tmp/{{ common_python_version_name }}"
-  when: not python_dir.stat.exists or python_version_check is failed or not python_shared_lib.stat.exists
+  when: rebuild_python
 
 - name: install new python
   shell: "umask 022; make && make install"
   args:
     chdir: "/var/tmp/{{ common_python_version_name }}"
-  when: not python_dir.stat.exists or python_version_check is failed or not python_shared_lib.stat.exists
+  when: rebuild_python
 
 # TODO install python to a known prefix like /usr/local to avoid this
 - name: add python lib to ld.so.conf

--- a/vars/bionic.yml
+++ b/vars/bionic.yml
@@ -24,6 +24,7 @@ common_os_packages:
   - git
   - libbz2-dev
   - libffi-dev
+  - libgdbm-dev
   - liblzma-dev
   - libncurses5-dev
   - libncursesw5-dev

--- a/vars/trusty.yml
+++ b/vars/trusty.yml
@@ -9,6 +9,7 @@ common_os_packages:
   - lib32z1-dev
   - libbz2-dev
   - libffi-dev
+  - libgdbm-dev
   - libgeos-c1
   - libpq-dev
   - libssl-dev


### PR DESCRIPTION
https://github.com/GSA/datagov-ckan-multi/issues/359

In pysaml 4.9.0, python with dbm (gdbm) support is necessary. Make sure it's installed and a flag exists to force a python rebuild.