### PR TITLE
[postfix] force variable allowing update of postfix role

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             - .venv
       - run:
           name: test
-          command: pipenv run molecule test --all 2>&1 | tee /tmp/molecule.log
+          command: pipenv run test 2>&1 | tee /tmp/molecule.log
       - store_artifacts:
           path: /tmp/molecule.log
           destination: molecule.log

--- a/Pipfile
+++ b/Pipfile
@@ -16,6 +16,6 @@ pytest-xdist = "*"
 python_version = "3.6"
 
 [scripts]
-test ="molecule test"
+test ="molecule test --all"
 debug ="molecule --debug test"
 converge="molecule converge"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,6 +69,13 @@
   tags:
     - unattended-upgrades
 
+# https://github.com/GSA/datagov-deploy/issues/2103
+- name: override registered postfix_main_cf file set in ansible-ubuntu-16
+  set_fact:
+    postfix_main_cf: /etc/postfix/main.cf
+  tags:
+    - postfix
+
 - name: Install postfix mail server
   import_role:
     name: oefenweb.postfix


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/2103

"Fix" variable collision by setting it to the default. This let's us update to v3.1.6.