### PR TITLE
[common] allow for custom shell prompt

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,13 @@
       {% endfor %}
     marker: "# {mark} ANSIBLE MANAGED LIST OF USERS"
 
+- name: Configure shell prompt
+  lineinfile:
+    path: /home/ubuntu/.bashrc
+    line: PS1='{{ common_shell_prompt }}'
+    state: present
+  when: common_shell_prompt is defined
+
 - name: Install build-essential
   import_role:
     name: ANXS.build-essential


### PR DESCRIPTION
This was discused as part of an Incident retro, but I can't find the issue.

This allows us to specify a custom shell prompt, so can remind operators they
are on production instances and avoid commands getting run in the wrong shell
window.